### PR TITLE
Fix name of test subdirectory in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,6 @@ if(CMAKE_VERSION VERSION_GREATER 3.7)
 endif()
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-	add_subdirectory(tests)
+	add_subdirectory(test)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,8 +4,11 @@ project(test)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 
-set(SOURCE_FILES ../RTree.h ../rtree_detail.h ../config.h ../bbox.h ../allocator.h ../indexable.h ../QuadTree.h ../quad_tree_detail.h custom_allocator.h)
-
 include_directories("${CMAKE_SOURCE_DIR}/../")
 
-add_executable(thst_test ${SOURCE_FILES} main.cpp)
+add_executable(thst_test main.cpp)
+
+target_link_libraries(thst_test
+	PRIVATE
+		THST::THST
+)


### PR DESCRIPTION
Fixes #15

This one has been manually tested on Debian Bullseye in both Debug and Release configurations.