### PR TITLE
RTree.h: line 1547 & 1540, drops const qualfier in assignment

### DIFF
--- a/RTree.h
+++ b/RTree.h
@@ -1537,14 +1537,14 @@ namespace spatial {
 	TREE_TEMPLATE
 		const ValueType &TREE_QUAL::base_iterator::operator*() const {
 		assert(valid());
-		typename base_type::StackElement &curTos = m_stack[m_tos - 1];
+		const typename base_type::StackElement &curTos = m_stack[m_tos - 1];
 		return curTos.node->values[curTos.branchIndex];
 	}
 
 	TREE_TEMPLATE
 		const typename TREE_QUAL::bbox_type &TREE_QUAL::base_iterator::bbox() const {
 		assert(valid());
-		typename base_type::StackElement &curTos = m_stack[m_tos - 1];
+		const typename base_type::StackElement &curTos = m_stack[m_tos - 1];
 		return curTos.node->bboxes[curTos.branchIndex];
 	}
 


### PR DESCRIPTION
# Brief Overview

binding reference of type 'typename base_type::StackElement' to value of type 'const StackElement' drops 'const' qualifier

# Fix

added const to the file RTree.h in the lines 1547 & 1540.

when compiled on Windows 11 mingw/clang16/clang-16.0.4 and mingw/mingw64/gcc-13.1.0