### PR TITLE
[fix] no member named bbox in QuadTreeNode

### DIFF
--- a/QuadTree.h
+++ b/QuadTree.h
@@ -652,7 +652,7 @@ namespace spatial {
 
 	TREE_TEMPLATE
 		const typename TREE_QUAL::bbox_type &TREE_QUAL::node_iterator::bbox() const {
-		return m_node->bbox;
+		return m_node->box;
 	}
 
 	TREE_TEMPLATE


### PR DESCRIPTION
Greetings, I am new to THST and I met some problems with the following code:

```c++
for (auto it = qtree.dbegin(); it.valid(); it.next()) {
  spatial::BoundingBox<double, 2> parent_bbox;
  for (auto node_it = it.child(); node_it.valid(); node_it.next()) {
    parent_bbox.extend(node_it.bbox());
  }
}
```

The error message is:

```bash
workspace_path/THST/QuadTree.h:655:18: error: 'spatial::QuadTree<double, ObbObjectWarp, 2, Indexer>::node_type' {aka 'struct spatial::detail::QuadTreeNode<double, ObbObjectWarp, 2>'} has no member named 'bbox'; did you mean 'box'?
  655 |   return m_node->bbox;
      |          ~~~~~~~~^~~~
      |          box
```

Then I look into the code and find that the `node_type` has no member named `bbox` but `box`. After fixing this, the code works well.