### PR TITLE
Fix syntax for dependent template arg

### DIFF
--- a/RTree.h
+++ b/RTree.h
@@ -1412,7 +1412,7 @@ namespace spatial {
 
 		if (node->isLeaf()) {
 			for (count_type index = 0; index < node->count; ++index) {
-				if (predicate(node->values[index]) && node->bboxes[index].intersectsRay<RealType>(rayOrigin, rayDirection)) {
+				if (predicate(node->values[index]) && node->bboxes[index].template intersectsRay<RealType>(rayOrigin, rayDirection)) {
 					*it = node->values[index];
 					++it;
 					++foundCount;
@@ -1423,7 +1423,7 @@ namespace spatial {
 			for (count_type index = 0; index < node->count; ++index) {
 				const bbox_type& nodeBBox = node->bboxes[index];
 
-				if (nodeBBox.intersectsRay<RealType>(rayOrigin, rayDirection)) {
+				if (nodeBBox.template intersectsRay<RealType>(rayOrigin, rayDirection)) {
 					rayQueryRec(node->children[index], rayOrigin, rayDirection, predicate, foundCount, it);
 				}
 			}


### PR DESCRIPTION
It is necessary to tell the compiler that we are using a template, because otherwise the syntax could be ambiguous dependent on what the template parameter is.

References:
cppreference.com/w/cpp/language-dependent_name
stackoverflow.com/questions/60062567/c-why-is-the-template-keyword-required-here